### PR TITLE
AWS capability

### DIFF
--- a/helm/cloudformation-operator/templates/deployment.yaml
+++ b/helm/cloudformation-operator/templates/deployment.yaml
@@ -61,7 +61,7 @@ spec:
         {{- end }}
         {{- end }}
 {{- if .Values.capability.enabled }}
-          - --capability CAPABILITY_IAM
+          - --capability=CAPABILITY_IAM
         {{- end }}
           env:
           - name: AWS_REGION


### PR DESCRIPTION
In the values.yaml if this is enabled 

https://github.com/linki/cloudformation-operator/blob/master/helm/cloudformation-operator/values.yaml#L39-L42

a crashloop occurs,

```
unknown flag: --capability "CAPABILITY_IAM"
Usage of /manager:
      --assume-role arn:aws:iam::123456789:role/cloudformation-operator   Assume AWS role when defined. Useful for stacks in another AWS account. Specify the full ARN, e.g. arn:aws:iam::123456789:role/cloudformation-operator
      --capability strings                                                The AWS CloudFormation capability to enable
      --dry-run                                                           If true, don't actually do anything.
      --health-probe-bind-address string                                  The address the probe endpoint binds to. (default ":8081")
    ```