### PR TITLE
Make possible to add custom command-line arguments to operator

### DIFF
--- a/helm/cloudformation-operator/templates/deployment.yaml
+++ b/helm/cloudformation-operator/templates/deployment.yaml
@@ -63,6 +63,11 @@ spec:
 {{- if .Values.capability.enabled }}
           - --capability=CAPABILITY_IAM
         {{- end }}
+{{- if .Values.extraArgs }}
+        {{- range $key, $value := .Values.extraArgs }}
+          - --{{ $key }}={{ $value }}
+        {{- end }}
+        {{- end }}
           env:
           - name: AWS_REGION
 {{- if .Values.operator.region }}

--- a/helm/cloudformation-operator/values.yaml
+++ b/helm/cloudformation-operator/values.yaml
@@ -54,6 +54,10 @@ resources:
 ## Pod Affinity
 affinity: {}
 
+# Additional command-line arguments to be passed to operator
+extraArgs:
+  #capability: CAPABILITY_NAMED_IAM
+
 ## A list of additional environment variables
 extraEnv:
   #- name: my_env


### PR DESCRIPTION
So, I need exactly `CAPABILITY_NAMED_IAM` argument. Adding `extraArgs` is not a complete solution for this problem, but it provides more agility. It will be useful in the future if new arguments come up.